### PR TITLE
Added try to native library loading

### DIFF
--- a/src/main/java/com/shockwave/pdfium/PdfiumCore.java
+++ b/src/main/java/com/shockwave/pdfium/PdfiumCore.java
@@ -16,11 +16,14 @@ public class PdfiumCore {
     private static final String TAG = PdfiumCore.class.getName();
 
     static {
-
-        System.loadLibrary("modpng");
-        System.loadLibrary("modft2");
-        System.loadLibrary("modpdfium");
-        System.loadLibrary("jniPdfium");
+        try {
+            System.loadLibrary("modpng");
+            System.loadLibrary("modft2");
+            System.loadLibrary("modpdfium");
+            System.loadLibrary("jniPdfium");
+        } catch (UnsatisfiedLinkError e) {
+            Log.e(TAG, "Native libraries failed to load." + e);
+        }
     }
 
     private native long nativeOpenDocument(int fd, String password);


### PR DESCRIPTION
If for some reason the native libraries are not available in the library search paths -  even though the libraries might already have been loaded as is the case in Android Things - then this causes the app to crash.

It would be better to catch the exception for the case that if the libraries are already in memory, then the app will continue normally. But if the libraries have not been loaded, then the app will crash - as usual.